### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/joezha/94bd382a-1aa3-439b-8892-fcfc9b22a94c/4087b482-6c41-475f-8cd0-9b58272309ea/_apis/work/boardbadge/095cf914-16ac-4ef9-bbc6-6479c632d05f)](https://codedev.ms/joezha/94bd382a-1aa3-439b-8892-fcfc9b22a94c/_boards/board/t/4087b482-6c41-475f-8cd0-9b58272309ea/Microsoft.RequirementCategory)
 Test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.