### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/joezha/b341f97e-b5a7-4adc-b9ca-05014486e0e3/131fb35a-8366-4645-8c93-13c655bf7ced/_apis/work/boardbadge/68f6ec76-551f-465e-a44c-3c6a826f9228)](https://codedev.ms/joezha/b341f97e-b5a7-4adc-b9ca-05014486e0e3/_boards/board/t/131fb35a-8366-4645-8c93-13c655bf7ced/Microsoft.RequirementCategory)
 Test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.