### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/mseng/7b41d569-d9c5-42b4-8ec1-c399143b777f/0a782e73-d07e-44cd-914f-5327640272a4/_apis/work/boardbadge/350492a4-7d5c-4788-b4a5-5e3953f9681f)](https://dev.azure.com/mseng/7b41d569-d9c5-42b4-8ec1-c399143b777f/_boards/board/t/0a782e73-d07e-44cd-914f-5327640272a4/Microsoft.RequirementCategory)
 Test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1549928. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.