### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/joezha2/069a59b1-db6d-44ef-936a-582f7df6ba26/ed47d444-85a4-4b2a-bb53-ed52bea32bab/_apis/work/boardbadge/a13bfb8c-d658-4ce7-8c69-c6911fdec493)](https://codedev.ms/joezha2/069a59b1-db6d-44ef-936a-582f7df6ba26/_boards/board/t/ed47d444-85a4-4b2a-bb53-ed52bea32bab/Microsoft.RequirementCategory)
 Test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/joezha2/069a59b1-db6d-44ef-936a-582f7df6ba26/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.