### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://codedev.ms/joezha/bb4332d2-b1f7-451e-98e7-961b285d994f/58f791fa-1b3a-49c7-a910-249bca1f9e9b/_apis/work/boardbadge/09cca3f7-e449-474b-8599-98ad078f94ac)](https://codedev.ms/joezha/bb4332d2-b1f7-451e-98e7-961b285d994f/_boards/board/t/58f791fa-1b3a-49c7-a910-249bca1f9e9b/Microsoft.RequirementCategory)
 [![Board Status](https://codedev.ms/joezha2/069a59b1-db6d-44ef-936a-582f7df6ba26/ed47d444-85a4-4b2a-bb53-ed52bea32bab/_apis/work/boardbadge/a13bfb8c-d658-4ce7-8c69-c6911fdec493)](https://codedev.ms/joezha2/069a59b1-db6d-44ef-936a-582f7df6ba26/_boards/board/t/ed47d444-85a4-4b2a-bb53-ed52bea32bab/Microsoft.RequirementCategory)
 Test
 s


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#2. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.